### PR TITLE
Avoid culling for internal transparent voxels

### DIFF
--- a/exploration/grid-poc/grid.py
+++ b/exploration/grid-poc/grid.py
@@ -14,6 +14,8 @@ from enum import Enum
 import copy
 import random
 from math import floor
+from voxels import voxels
+import types
 
 UNSATURATED_PRESSURE_GRADIENT = 0.5
 SATURATED_PRESSURE_GRADIENT = 1.0
@@ -141,7 +143,7 @@ def interpolate(col1, col2, s):
         (col2[1] * s) + (col1[1] * (1 - s)),
         (col2[2] * s) + (col1[2] * (1 - s)),
         #(col2[3] * s) + (col1[3] * (1 - s)),
-        0.5 if s > 0.5 else 0.0
+        s if s > 0.2 else 0.0
     )
 
 class Soil(Cell):
@@ -159,7 +161,7 @@ class Soil(Cell):
         self.colour = interpolate(water, water, scale)
 
 class Rock(Cell):
-    colour = (0.6, 0.6, 0.6, 0.5)
+    colour = (0.6, 0.6, 0.6, 1.0)
 
     def __init__(self):
         super().__init__()
@@ -405,13 +407,16 @@ class Grid():
                     colors[x, y, z] = cell.colour
 
         self.ax.clear()
-        self.ax.voxels(voxelarray, facecolors=colors, edgecolor='k')
+        self.ax.voxels(voxelarray, facecolors=colors, edgecolor='k', internal_faces=True)
 
     def main(self):
         random.seed(1)
         self.populate()
 
         self.ax = plt.figure().add_subplot(projection='3d')
+
+        self.ax.voxels = types.MethodType(voxels, self.ax)
+
         self.plot()
         plt.ion()
         plt.show()
@@ -421,10 +426,10 @@ class Grid():
             #print("Start update")
             self.update()
             #print("End update")
-            self.display_slice(7)
+            #self.display_slice(7)
             self.plot()
             plt.draw()
-            plt.pause(0.1)
+            plt.pause(0.01)
             #sleep(0.25)
 
 if __name__ == "__main__":

--- a/exploration/grid-poc/voxels.py
+++ b/exploration/grid-poc/voxels.py
@@ -1,0 +1,139 @@
+#!/bin/python3
+# vim: et:ts=4:sts=4:sw=4
+
+# Add internal_faces flag to voxel rendering
+
+from mpl_toolkits.mplot3d import Axes3D, art3d  # NOQA
+from collections import defaultdict
+import numpy as np
+
+def voxels(self, *args, **kwargs):
+
+    if len(args) >= 3:
+        # underscores indicate position only
+        def voxels(__x, __y, __z, filled, **kwargs):
+            return (__x, __y, __z), filled, kwargs
+    else:
+        def voxels(filled, **kwargs):
+            return None, filled, kwargs
+
+    xyz, filled, kwargs = voxels(*args, **kwargs)
+
+    # check dimensions
+    if filled.ndim != 3:
+        raise ValueError("Argument filled must be 3-dimensional")
+    size = np.array(filled.shape, dtype=np.intp)
+
+    # check xyz coordinates, which are one larger than the filled shape
+    coord_shape = tuple(size + 1)
+    if xyz is None:
+        x, y, z = np.indices(coord_shape)
+    else:
+        x, y, z = (np.broadcast_to(c, coord_shape) for c in xyz)
+
+    def _broadcast_color_arg(color, name):
+        if np.ndim(color) in (0, 1):
+            # single color, like "red" or [1, 0, 0]
+            return np.broadcast_to(color, filled.shape + np.shape(color))
+        elif np.ndim(color) in (3, 4):
+            # 3D array of strings, or 4D array with last axis rgb
+            if np.shape(color)[:3] != filled.shape:
+                raise ValueError(
+                    "When multidimensional, {} must match the shape of "
+                    "filled".format(name))
+            return color
+        else:
+            raise ValueError("Invalid {} argument".format(name))
+
+    # intercept the facecolors, handling defaults and broacasting
+    facecolors = kwargs.pop('facecolors', None)
+    if facecolors is None:
+        facecolors = self._get_patches_for_fill.get_next_color()
+    facecolors = _broadcast_color_arg(facecolors, 'facecolors')
+
+    # broadcast but no default on edgecolors
+    edgecolors = kwargs.pop('edgecolors', None)
+    edgecolors = _broadcast_color_arg(edgecolors, 'edgecolors')
+
+    # include possibly occluded internal faces or not
+    internal_faces = kwargs.pop('internal_faces', False)
+
+    # always scale to the full array, even if the data is only in the center
+    self.auto_scale_xyz(x, y, z)
+
+    # points lying on corners of a square
+    square = np.array([
+        [0, 0, 0],
+        [0, 1, 0],
+        [1, 1, 0],
+        [1, 0, 0]
+    ], dtype=np.intp)
+
+    voxel_faces = defaultdict(list)
+
+    def permutation_matrices(n):
+        """ Generator of cyclic permutation matices """
+        mat = np.eye(n, dtype=np.intp)
+        for i in range(n):
+            yield mat
+            mat = np.roll(mat, 1, axis=0)
+
+    for permute in permutation_matrices(3):
+        pc, qc, rc = permute.T.dot(size)
+        pinds = np.arange(pc)
+        qinds = np.arange(qc)
+        rinds = np.arange(rc)
+
+        square_rot = square.dot(permute.T)
+
+        for p in pinds:
+            for q in qinds:
+                p0 = permute.dot([p, q, 0])
+                i0 = tuple(p0)
+                if filled[i0]:
+                    voxel_faces[i0].append(p0 + square_rot)
+
+                # draw middle faces
+                for r1, r2 in zip(rinds[:-1], rinds[1:]):
+                    p1 = permute.dot([p, q, r1])
+                    p2 = permute.dot([p, q, r2])
+                    i1 = tuple(p1)
+                    i2 = tuple(p2)
+                    if filled[i1] and (internal_faces or not filled[i2]):
+                        voxel_faces[i1].append(p2 + square_rot)
+                    elif (internal_faces or not filled[i1]) and filled[i2]:
+                        voxel_faces[i2].append(p2 + square_rot)
+
+                # draw upper faces
+                pk = permute.dot([p, q, rc-1])
+                pk2 = permute.dot([p, q, rc])
+                ik = tuple(pk)
+                if filled[ik]:
+                    voxel_faces[ik].append(pk2 + square_rot)
+
+    # iterate over the faces, and generate a Poly3DCollection for each voxel
+    polygons = {}
+    for coord, faces_inds in voxel_faces.items():
+        # convert indices into 3D positions
+        if xyz is None:
+            faces = faces_inds
+        else:
+            faces = []
+            for face_inds in faces_inds:
+                ind = face_inds[:, 0], face_inds[:, 1], face_inds[:, 2]
+                face = np.empty(face_inds.shape)
+                face[:, 0] = x[ind]
+                face[:, 1] = y[ind]
+                face[:, 2] = z[ind]
+                faces.append(face)
+
+        poly = art3d.Poly3DCollection(faces,
+            facecolors=facecolors[coord],
+            edgecolors=edgecolors[coord],
+            **kwargs
+        )
+        self.add_collection3d(poly)
+        polygons[coord] = poly
+
+    return polygons
+


### PR DESCRIPTION
By default matplotlib will cull internal voxels even if the surrounding voxels have transparency. This change adds an extra "internal_faces" parameter to the ax.voxel() method which, when set, ensures internal voxels are still rendered.

This change is based on the following upstream WIP PR:

https://github.com/matplotlib/matplotlib/pull/9927